### PR TITLE
Fix library warning

### DIFF
--- a/auto_nodetitle.module
+++ b/auto_nodetitle.module
@@ -70,7 +70,7 @@ function auto_nodetitle_form_node_type_form_alter(&$form, FormStateInterface $fo
     '#group' => 'additional_settings',
     '#tree' => TRUE,
     '#attached' => array(
-      'library' => array('auto_nodetitle.auto_node_title'),
+      'library' => array('auto_nodetitle/auto_nodetitle.auto_node_title'),
     ),
   );
   $form['auto_nodetitle']['status'] = array(


### PR DESCRIPTION
When saving content type configuration the following notice and warning are displayed:

```
Notice: Undefined offset: 1 in Drupal\Core\Asset\LibraryDependencyResolver->doGetDependencies() (line 58 of core/lib/Drupal/Core/Asset/LibraryDependencyResolver.php).
User warning: The following theme is missing from the file system: auto_nodetitle.auto_node_title in drupal_get_filename() (line 233 of core/includes/bootstrap.inc).
```
